### PR TITLE
Remove CI trigger on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR should be merged after #18

Superseded by running on all pushes, it was making the workflow run twice.